### PR TITLE
Change getControl and getDevice as nullable

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -18,7 +18,8 @@ const config: Config = {
   setupFiles: [
     '<rootDir>/tests/dotenv-setup.ts',
     '<rootDir>/tests/wb-engine-setup.ts'
-  ]
+  ],
+  testTimeout: 500
 }
 
 export default config

--- a/src/wb-rules-modules/core/index.ts
+++ b/src/wb-rules-modules/core/index.ts
@@ -1,0 +1,1 @@
+export * from './wrappers'

--- a/src/wb-rules-modules/core/wrappers.ts
+++ b/src/wb-rules-modules/core/wrappers.ts
@@ -1,0 +1,30 @@
+/**
+ * Позволяет получить объект для работы с указанным устройством.
+ * @param deviceId Идентификатор устройства.
+ */
+export function getDeviceSafe(deviceId: string) {
+  let device: Device | undefined
+
+  return {
+    /** Возвращает существующий объект или пытается найти, если его ещё нет. */
+    get safe() {
+      return device ??= getDevice(deviceId)
+    }
+  }
+}
+
+/**
+ * Позволяет получить объект для работы с указанным контролом устройства.
+ * @param deviceId Идентификатор устройства.
+ * @param controlId Идентификатор контрола.
+ */
+export function getControlSafe(deviceId: string, controlId: string) {
+  let control: Cell | undefined
+
+  return {
+    /** Возвращает существующий объект или пытается найти, если его ещё нет. */
+    get safe() {
+      return control ??= getControl(`${deviceId}/${controlId}`)
+    }
+  }
+}

--- a/src/wb-rules-modules/moes-scene-switch.ts
+++ b/src/wb-rules-modules/moes-scene-switch.ts
@@ -1,3 +1,4 @@
+import { getControlSafe } from '@wbm/core'
 import { isString } from '@wbm/type-guards'
 import { useEvent } from '@wbm/event'
 import { usePolyfills } from '@wbm/polyfills'
@@ -54,23 +55,23 @@ interface SceneSwitchOptions {
   deviceId: string
 }
 
-/**
- * Построитель объекта для обработки событий сценарного пульта Moes.
- */
+/** Построитель объекта для обработки событий сценарного пульта Moes. */
 export function useSceneSwitch(options: SceneSwitchOptions) {
   const singleClickEvent = useEvent<ClickEventArgs>()
   const doubleClickEvent = useEvent<ClickEventArgs>()
   const longPressEvent = useEvent<ClickEventArgs>()
 
-  const lastSeen = getControl(`${options.deviceId}/last_seen`)
-  const startupStamp = lastSeen.getValue()
+  const lastSeen = getControlSafe(options.deviceId, 'last_seen')
+  const startupStamp = lastSeen.safe?.getValue()
 
   trackMqtt(`/devices/${options.deviceId}/controls/action`, (payload) => {
-    const stamp = lastSeen.getValue()
+    const stamp = lastSeen.safe?.getValue()
 
     // Если временная метка не поменялась, игнорируем сообщение.
-    if (stamp === startupStamp)
+    if (stamp === startupStamp) {
+      log.debug(`Подавление Retained-сообщения '${payload.value.toString()}' для метки '${stamp?.toString() ?? 'None'}'`)
       return
+    }
 
     const { button, action } = parseAction(payload.value)
 

--- a/tests/wb-engine/getControl.ts
+++ b/tests/wb-engine/getControl.ts
@@ -1,5 +1,6 @@
 import { mock } from 'jest-mock-extended'
 
+/** Имитатор конструкции getControl. */
 export function useGetControl() {
   let values: Record<string, MqttValue> = {}
 
@@ -13,14 +14,21 @@ export function useGetControl() {
     }
   }
 
-  function setValue(devicePath: string, value: MqttValue) {
-    values[devicePath] = value
+  function setValue(deviceId: string, controlId: string, value: MqttValue) {
+    values[`${deviceId}/${controlId}`] = value
+  }
+
+  function setValues(presets: { deviceId: string, controlId: string, value: MqttValue }[]) {
+    presets.forEach((preset) => {
+      values[`${preset.deviceId}/${preset.controlId}`] = preset.value
+    })
   }
 
   reset()
 
   return {
     reset,
-    setValue
+    setValue,
+    setValues
   }
 }

--- a/tests/wb-rules-modules/moes-scene-switch.test.ts
+++ b/tests/wb-rules-modules/moes-scene-switch.test.ts
@@ -20,8 +20,8 @@ test('Should be parsed only for keys of Button', () => {
 })
 
 test('1st button click is handled', (done) => {
-  const topic = `/devices/${process.env.APP_SCENESW_1}/controls/action`
-  const control = `${process.env.APP_SCENESW_1}/last_seen`
+  const deviceId = process.env.APP_SCENESW_1
+  const topic = `/devices/${deviceId}/controls/action`
 
   const moesSwitch = useSceneSwitch({
     deviceId: process.env.APP_SCENESW_1
@@ -34,7 +34,7 @@ test('1st button click is handled', (done) => {
     done()
   })
 
-  getControl.setValue(control, '1750000000020')
+  getControl.setValue(deviceId, 'last_seen', '1750000000020')
 
   trackMqtt.run({
     topic,
@@ -43,8 +43,8 @@ test('1st button click is handled', (done) => {
 })
 
 test('4th button hold is handled', (done) => {
-  const topic = `/devices/${process.env.APP_SCENESW_1}/controls/action`
-  const control = `${process.env.APP_SCENESW_1}/last_seen`
+  const deviceId = process.env.APP_SCENESW_1
+  const topic = `/devices/${deviceId}/controls/action`
 
   const moesSwitch = useSceneSwitch({
     deviceId: process.env.APP_SCENESW_1
@@ -57,7 +57,7 @@ test('4th button hold is handled', (done) => {
     done()
   })
 
-  getControl.setValue(control, '1750000000020')
+  getControl.setValue(deviceId, 'last_seen', '1750000000020')
 
   trackMqtt.run({
     topic,
@@ -66,8 +66,8 @@ test('4th button hold is handled', (done) => {
 })
 
 test('Multiple buttons is handled', () => {
-  const topic = `/devices/${process.env.APP_SCENESW_1}/controls/action`
-  const control = `${process.env.APP_SCENESW_1}/last_seen`
+  const deviceId = process.env.APP_SCENESW_1
+  const topic = `/devices/${deviceId}/controls/action`
 
   let count = 0
 
@@ -82,7 +82,10 @@ test('Multiple buttons is handled', () => {
     count += 1
   })
 
-  getControl.setValue(control, '1750000000020')
+  getControl.setValues([
+    { deviceId, controlId: 'last_seen', value: '1750000000020' },
+    { deviceId, controlId: 'battery', value: '100' }
+  ])
 
   trackMqtt.run([
     { topic, value: '1_hold' },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "./dist",
     "paths": {
       "@wbm*": [
-        "./src/wb-rules-modules*"
+        "./src/wb-rules-modules/*"
       ]
     },
     "allowJs": true,
@@ -17,7 +17,7 @@
   },
   "include": [
     "src/wb-rules/*",
-    "src/wb-rules-modules/*",
+    "src/wb-rules-modules/**/*",
     "types/*"
   ],
   "tsc-alias": {

--- a/types/wb-rules.d.ts
+++ b/types/wb-rules.d.ts
@@ -51,7 +51,7 @@ declare var log: WbLog
 
 declare type WbDevControl = Record<string, unknown>
 
-declare type WbDev = Record<string, WbDevControl>
+declare type WbDev = Record<string, WbDevControl | undefined>
 
 /**
  * Объект доступа к MQTT-топикам устройства
@@ -281,16 +281,16 @@ declare function defineVirtualDevice(
 ): Device
 
 /**
- * Возвращает указанное устройство.
+ * Позволяет получить объект для работы с указанным устройством.
  * @param deviceId Идентификатор устройства.
  */
-declare function getDevice(deviceId: string): Device
+declare function getDevice(deviceId: string): Device | undefined
 
 /**
- * Возвращает указанный контрол устройства.
+ * Позволяет получить объект для работы с указанным контролом устройства.
  * @param path Строка в формате "deviceId/controlId"
  */
-declare function getControl(path: string): Cell
+declare function getControl(path: string): Cell | undefined
 
 /**
  * запускает периодический таймер с указанным интервалом


### PR DESCRIPTION
<!-- Предоставьте общее описание ваших изменений в названии выше. -->
<!-- Заголовок должен быть кратким и описательным, так как он будет использоваться в качестве Commit Message. -->

## Описание
<!-- Опишите ваши изменения в подробностях, зачем и почему. -->
<!-- Укажите любые Issue, которые решаются этим PR -->
<!-- например, решает #1000 или исправляет #2145 -->
Closes #24 - [Runtime, Moes Scene Switch] Сценарий ломается после перезапуска контроллера

## Как это тестировалось?
<!-- По возможности, все PR должны включать юнит-тесты. -->
<!-- Опишите, как Вы тестировали свои изменения. -->
<!-- Вы создали новые тесты или обновили существующие? -->
Ошибка проявляется только при перезапуске контроллера, поскольку в этот момент ещё не проинициализированы необходимые топики. Соответствующие тесты выполнялись на контроллере.

## Тип изменений
<!-- Какой тип изменений вносят ваши правки? Поставьте англ. символ `x` в одно из полей ниже, которое подходит лучше всего: -->
- [x] Bug Fix (устраняет проблему, не приводит к нарушению обратной совместимости)
- [x] New Feature (добавляет функционал, не приводит к нарушению обратной совместимости)
- [ ] Breacking Change (исправление или добавление функционала, приводящие к нарушению обратной совместимости)
- [ ] Documentation (исправление или улучшение сопроводительной документации)

<!-- Если изменения носят визуальный характер, предоставьте скриншоты до/после. Если есть подвижные части, прикрепите видео в хорошем качестве. -->
Добавлен «синтаксический сахар» в виде обёртки `getControlSafe()` - возвращает объект с доступом к контролу, который продолжает попытки инициализации контрола через свойство `safe`, что эквивалентно повторному вызову `getControl`:
```typescript
const lastSeen = getControlSafe(options.deviceId, 'last_seen')
const startupStamp = lastSeen.safe?.getValue()
```
Как только объект обнаруживается, он сразу кэшируется и переиспользуется.

## Чеклист
<!-- Пройдитесь по всем пунктам и поставьте крестик, где это применимо. -->
- [x] PR отправлен в правильную ветку (`latest`)
- [x] Мой код соответствует стилю кода этого проекта
- [x] Я добавил соответствующие тесты
